### PR TITLE
Allow target/rel attributes in fobi content_text links

### DIFF
--- a/mp/settings.py
+++ b/mp/settings.py
@@ -247,3 +247,12 @@ LOGGING = {
         },
     },
 }
+
+# fobi content_text sanea el HTML con bleach. Por defecto en <a> solo permite
+# href/title, por lo que borra target y rel. Los habilitamos para poder abrir
+# los links de pago en una pestaña nueva con rel="noopener noreferrer".
+FOBI_PLUGIN_CONTENT_TEXT_ALLOWED_ATTRIBUTES = {
+    "a": ["href", "title", "target", "rel"],
+    "abbr": ["title"],
+    "acronym": ["title"],
+}


### PR DESCRIPTION
fobi sanitizes content_text HTML with bleach; the default whitelist only permits href/title on <a>, stripping target and rel. Override FOBI_PLUGIN_CONTENT_TEXT_ALLOWED_ATTRIBUTES so payment links can open in a new tab with rel="noopener noreferrer".