### PR TITLE
Agregar exportación de inscriptos a Excel (.xlsx)

### DIFF
--- a/inscripcion/views.py
+++ b/inscripcion/views.py
@@ -37,6 +37,7 @@ from fobi.base import (
 
 from fobi.settings import GET_PARAM_INITIAL_DATA, DEBUG
 import csv
+import io
 from django.contrib.auth import login, authenticate, logout
 from django.contrib.auth.forms import AuthenticationForm
 
@@ -202,12 +203,14 @@ def inscriptos_actividad(request, idActividad):
     m, txt = encode_data(str(actividad.id))
     url_contacto = request.scheme + '://' + request.META['HTTP_HOST'] + '/inscriptos?m=' + urllib.parse.quote(m) + '&text=' + urllib.parse.quote(txt)
     url_csv = request.scheme + '://' + request.META['HTTP_HOST'] + '/csv?m=' + urllib.parse.quote(m) + '&text=' + urllib.parse.quote(txt)
+    url_excel = request.scheme + '://' + request.META['HTTP_HOST'] + '/excel?m=' + urllib.parse.quote(m) + '&text=' + urllib.parse.quote(txt)
     context = {'lista_inscriptos': lista_inscriptos,
                'actividad': actividad,
                'cabecera': cabecera,
                'jsontitles': jsontitles,
                'url_contacto': url_contacto,
                'url_csv': url_csv,
+               'url_excel': url_excel,
                }
     return render(request, 'admin/inscriptos.html', context)
 
@@ -244,11 +247,13 @@ def lista_inscriptos(request):
             inscripto.datos = json.loads(inscripto.datos)
 
     url_csv = request.scheme + '://' + request.META['HTTP_HOST'] + '/csv?m=' + urllib.parse.quote(m) + '&text=' + urllib.parse.quote(text)
+    url_excel = request.scheme + '://' + request.META['HTTP_HOST'] + '/excel?m=' + urllib.parse.quote(m) + '&text=' + urllib.parse.quote(text)
     context = {'lista_inscriptos': lista_inscriptos,
                'actividad': actividad,
                'cabecera': cabecera,
                'jsontitles': jsontitles,
                'url_csv': url_csv,
+               'url_excel': url_excel,
                }
     return render(request, 'inscriptos.html', context)
 
@@ -305,6 +310,70 @@ def descargar_csv(request):
         row.append(inscripto.fechaInscripcion)
         writer.writerow(row)
 
+    return response
+
+
+def descargar_excel(request):
+    from openpyxl import Workbook
+
+    m = request.GET.get('m')
+    text = request.GET.get('text')
+    try:
+        actividad_id = decode_data(m, text)
+    except:
+        mensaje = u'La url no es correcta.'
+        return render(
+            request,
+            'error.html',
+            {'mensaje': mensaje},
+        )
+    actividad = get_object_or_404(Actividad, pk=actividad_id)
+    form_entry = actividad.formDinamico
+
+    form_element_entries = form_entry.formelemententry_set.all()[:]
+
+    lista_inscriptos = InscripcionBase.objects.filter(actividad=actividad).order_by('puesto')
+    for inscripto in lista_inscriptos:
+        if inscripto.datos != None:
+            inscripto.datos = json.loads(inscripto.datos)
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Inscriptos"
+
+    cabecera = ['Puesto', 'Nombre', 'Apellido', 'Cedula', 'Telefono', 'Email']
+    jsontitles = []
+    for entry in form_element_entries:
+        aux = json.loads(entry.plugin_data)
+        # Saltar elementos de contenido sin label/name (no son campos).
+        if "label" not in aux or "name" not in aux:
+            continue
+        jsontitles.append(aux["name"])
+        cabecera.append(aux["label"])
+    cabecera.append('Fecha de inscripcion')
+    ws.append(cabecera)
+
+    for inscripto in lista_inscriptos:
+        fila = [inscripto.puesto, inscripto.nombre, inscripto.apellido,
+                inscripto.cedula, inscripto.celular, inscripto.mail]
+        for dato in jsontitles:
+            try:
+                fila.append(inscripto.datos[dato])
+            except (KeyError, TypeError):
+                fila.append("")
+        # openpyxl no acepta datetimes con tzinfo; lo pasamos a texto.
+        fila.append(str(inscripto.fechaInscripcion))
+        ws.append(fila)
+
+    buffer = io.BytesIO()
+    wb.save(buffer)
+    buffer.seek(0)
+
+    response = HttpResponse(
+        buffer.getvalue(),
+        content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    )
+    response['Content-Disposition'] = 'attachment; filename="inscriptos.xlsx"'
     return response
 
 

--- a/mp/urls.py
+++ b/mp/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     re_path(r'^actividad/(?P<idActividad>\d+)/$', inscripcion_views.inscripcion_actividad, name='actividad'),
     re_path(r'^lista/(?P<idActividad>\d+)/$', inscripcion_views.inscriptos_actividad, name='lista'),
     re_path(r'^csv/$', inscripcion_views.descargar_csv, name='csv'),
+    re_path(r'^excel/$', inscripcion_views.descargar_excel, name='excel'),
     re_path(r'^inscripto/$', inscripcion_views.inscripcion_extra, name='inscripto'),
     re_path(r'^inscriptos/$', inscripcion_views.lista_inscriptos, name='inscriptos'),
     re_path(r'^actividades/$', inscripcion_views.lista_actividades, name='actividades'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ django-autoslug>=1.9.9  # Required by django-fobi
 django-nonefield>=0.4  # Required by django-fobi
 transliterate>=1.10.2  # Required by django-fobi
 Pillow>=10.0.0  # Required for image handling
+openpyxl>=3.1.0  # Exportar inscriptos a Excel (.xlsx)

--- a/templates/admin/inscriptos.html
+++ b/templates/admin/inscriptos.html
@@ -16,6 +16,7 @@
                 <p><b>Url para el contacto: </b><a href="{{ url_contacto }}">{{ url_contacto }}</a></p>
 
                 <a class="btn btn-default" href="{{ url_csv }}">Descargar csv</a>
+                <a class="btn btn-default" href="{{ url_excel }}">Descargar Excel</a>
                 <div class="table-responsive">
                     <table class="table table-striped table-condensed">
                     <thead>

--- a/templates/inscriptos.html
+++ b/templates/inscriptos.html
@@ -14,6 +14,7 @@
         <div class="col-sm-12 ">
             <div>
                 <a class="btn btn-default" href="{{ url_csv }}">Descargar csv</a>
+                <a class="btn btn-default" href="{{ url_excel }}">Descargar Excel</a>
                 <div class="table-responsive">
                     <table class="table table-striped table-condensed">
                     <thead>


### PR DESCRIPTION
Nuevo botón 'Descargar Excel' junto a 'Descargar csv' en las vistas de inscriptos (admin y pública). Espeja la lógica del CSV pero genera un .xlsx con openpyxl, saltando los elementos de contenido de fobi sin label/name.

- descargar_excel view + ruta /excel/
- url_excel en inscriptos_actividad y lista_inscriptos
- openpyxl en requirements.txt