### PR TITLE
Reemplazar exportación CSV por Excel

### DIFF
--- a/inscripcion/views.py
+++ b/inscripcion/views.py
@@ -36,7 +36,6 @@ from fobi.base import (
 )
 
 from fobi.settings import GET_PARAM_INITIAL_DATA, DEBUG
-import csv
 import io
 from django.contrib.auth import login, authenticate, logout
 from django.contrib.auth.forms import AuthenticationForm
@@ -202,14 +201,12 @@ def inscriptos_actividad(request, idActividad):
             inscripto.datos = json.loads(inscripto.datos)
     m, txt = encode_data(str(actividad.id))
     url_contacto = request.scheme + '://' + request.META['HTTP_HOST'] + '/inscriptos?m=' + urllib.parse.quote(m) + '&text=' + urllib.parse.quote(txt)
-    url_csv = request.scheme + '://' + request.META['HTTP_HOST'] + '/csv?m=' + urllib.parse.quote(m) + '&text=' + urllib.parse.quote(txt)
     url_excel = request.scheme + '://' + request.META['HTTP_HOST'] + '/excel?m=' + urllib.parse.quote(m) + '&text=' + urllib.parse.quote(txt)
     context = {'lista_inscriptos': lista_inscriptos,
                'actividad': actividad,
                'cabecera': cabecera,
                'jsontitles': jsontitles,
                'url_contacto': url_contacto,
-               'url_csv': url_csv,
                'url_excel': url_excel,
                }
     return render(request, 'admin/inscriptos.html', context)
@@ -246,71 +243,14 @@ def lista_inscriptos(request):
         if inscripto.datos != None:
             inscripto.datos = json.loads(inscripto.datos)
 
-    url_csv = request.scheme + '://' + request.META['HTTP_HOST'] + '/csv?m=' + urllib.parse.quote(m) + '&text=' + urllib.parse.quote(text)
     url_excel = request.scheme + '://' + request.META['HTTP_HOST'] + '/excel?m=' + urllib.parse.quote(m) + '&text=' + urllib.parse.quote(text)
     context = {'lista_inscriptos': lista_inscriptos,
                'actividad': actividad,
                'cabecera': cabecera,
                'jsontitles': jsontitles,
-               'url_csv': url_csv,
                'url_excel': url_excel,
                }
     return render(request, 'inscriptos.html', context)
-
-
-def descargar_csv(request):
-    m = request.GET.get('m')
-    text = request.GET.get('text')
-    try:
-        actividad_id = decode_data(m, text)
-    except:
-        mensaje = u'La url no es correcta.'
-        return render(
-            request,
-            'error.html',
-            {'mensaje': mensaje},
-        )
-    actividad = get_object_or_404(Actividad, pk=actividad_id)
-    form_entry = actividad.formDinamico
-
-    form_element_entries = form_entry.formelemententry_set.all()[:]
-
-    lista_inscriptos = InscripcionBase.objects.filter(actividad=actividad).order_by('puesto')
-    for inscripto in lista_inscriptos:
-        if inscripto.datos != None:
-            inscripto.datos = json.loads(inscripto.datos)
-
-    response = HttpResponse(content_type='text/csv')
-    response['Content-Disposition'] = 'attachment; filename="inscriptos.csv"'
-
-    writer = csv.writer(response, delimiter=';')
-    row = ['Puesto', 'Nombre', 'Apellido', 'Cedula', 'Telefono', 'Email']
-    jsontitles=[]
-    for entry in form_element_entries:
-        aux = json.loads(entry.plugin_data)
-        # Saltar elementos de contenido sin label/name (no son campos).
-        if "label" not in aux or "name" not in aux:
-            continue
-        jsontitles.append(aux["name"])
-        row.append(aux["label"].encode('utf-8'))
-    row.append('Fecha de inscripcion')
-    writer.writerow(row)
-
-    for inscripto in lista_inscriptos:
-        row = [inscripto.puesto, inscripto.nombre.encode('utf-8'), inscripto.apellido.encode('utf-8'),
-               inscripto.cedula.encode('utf-8'), inscripto.celular.encode('utf-8'), inscripto.mail.encode('utf-8')]
-        for dato in jsontitles:
-            try:
-                if(isinstance(inscripto.datos[dato], str)):
-                    row.append(inscripto.datos[dato].encode('utf-8'))
-                else:
-                    row.append(str(inscripto.datos[dato]))
-            except:
-                row.append("".encode('utf-8'))
-        row.append(inscripto.fechaInscripcion)
-        writer.writerow(row)
-
-    return response
 
 
 def descargar_excel(request):

--- a/mp/urls.py
+++ b/mp/urls.py
@@ -29,7 +29,6 @@ urlpatterns = [
     re_path(r'^form/(?P<form_entry_slug>[\w_\-]+)/$', inscripcion_views.form, name='form'),
     re_path(r'^actividad/(?P<idActividad>\d+)/$', inscripcion_views.inscripcion_actividad, name='actividad'),
     re_path(r'^lista/(?P<idActividad>\d+)/$', inscripcion_views.inscriptos_actividad, name='lista'),
-    re_path(r'^csv/$', inscripcion_views.descargar_csv, name='csv'),
     re_path(r'^excel/$', inscripcion_views.descargar_excel, name='excel'),
     re_path(r'^inscripto/$', inscripcion_views.inscripcion_extra, name='inscripto'),
     re_path(r'^inscriptos/$', inscripcion_views.lista_inscriptos, name='inscriptos'),

--- a/templates/admin/inscriptos.html
+++ b/templates/admin/inscriptos.html
@@ -15,7 +15,6 @@
             <div>
                 <p><b>Url para el contacto: </b><a href="{{ url_contacto }}">{{ url_contacto }}</a></p>
 
-                <a class="btn btn-default" href="{{ url_csv }}">Descargar csv</a>
                 <a class="btn btn-default" href="{{ url_excel }}">Descargar Excel</a>
                 <div class="table-responsive">
                     <table class="table table-striped table-condensed">

--- a/templates/inscriptos.html
+++ b/templates/inscriptos.html
@@ -13,7 +13,6 @@
     <div class="row">
         <div class="col-sm-12 ">
             <div>
-                <a class="btn btn-default" href="{{ url_csv }}">Descargar csv</a>
                 <a class="btn btn-default" href="{{ url_excel }}">Descargar Excel</a>
                 <div class="table-responsive">
                     <table class="table table-striped table-condensed">


### PR DESCRIPTION
Se quita el CSV por completo (botón, view descargar_csv, ruta /csv/ y url_csv en las vistas de inscriptos). Queda solo la descarga en Excel.