### PR TITLE
Rediseño de estilo: capa moderna sobre Bootstrap 3

### DIFF
--- a/static/css/signin.css
+++ b/static/css/signin.css
@@ -1,40 +1,52 @@
+/* Pantalla de login — card centrada, usa los tokens de theme.css */
+
 body {
-  padding-top: 40px;
-  padding-bottom: 40px;
-  background-color: #eee;
+  padding: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ground);
+}
+
+.container {
+  width: 100%;
+  max-width: none;
+  display: flex;
+  justify-content: center;
 }
 
 .form-signin {
-  max-width: 330px;
-  padding: 15px;
-  margin: 0 auto;
+  width: 100%;
+  max-width: 360px;
+  margin: 24px;
+  padding: 34px 30px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--card-radius);
 }
-.form-signin .form-signin-heading,
-.form-signin .checkbox {
-  margin-bottom: 10px;
+
+.form-signin h2 {
+  font-family: var(--serif);
+  font-weight: 600;
+  color: var(--ink);
+  font-size: 24px;
+  margin: 0 0 18px;
+  text-align: center;
 }
-.form-signin .checkbox {
-  font-weight: normal;
-}
+
 .form-signin .form-control {
-  position: relative;
   height: auto;
-  -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
-          box-sizing: border-box;
-  padding: 10px;
-  font-size: 16px;
+  min-height: 44px;
+  padding: 11px 13px;
+  font-size: 15px;
+  margin-bottom: 12px;
 }
-.form-signin .form-control:focus {
-  z-index: 2;
+
+.form-signin .btn {
+  margin-top: 6px;
 }
-.form-signin input[type="email"] {
-  margin-bottom: -1px;
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.form-signin input[type="password"] {
-  margin-bottom: 10px;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
+
+.form-signin p {
+  margin: 0;
 }

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,220 @@
+/*
+ * theme.css — capa de estilo moderna sobre Bootstrap 3.
+ * Se carga DESPUES de bootstrap.min.css para sobrescribir sus clases sin
+ * cambiar el markup ni el render de fobi. Paleta "azul peregrino".
+ * Soporta modo claro (por defecto) y oscuro automatico (segun el SO).
+ */
+
+:root {
+  --ground: #F4F5F3;
+  --surface: #FFFFFF;
+  --surface-2: #EEF0EC;
+  --ink: #1C2024;
+  --ink-soft: #545A62;
+  --ink-mute: #868D95;
+  --line: #E3E5E1;
+  --accent: #2C5169;
+  --accent-strong: #1F3C50;
+  --accent-soft: #E7EEF2;
+  --ochre: #B98A3E;
+
+  --good-bg: #E4F0E9; --good-fg: #285C42; --good-line: #BFDBCC;
+  --warn-bg: #F3EAD8; --warn-fg: #7C561A; --warn-line: #E4D3AE;
+  --bad-bg: #F6E4E4;  --bad-fg: #8C2F2F;  --bad-line: #E3BCBC;
+  --info-bg: #E7EEF2; --info-fg: #1F3C50; --info-line: #C6D6E0;
+
+  --radius: 6px;
+  --card-radius: 12px;
+  --serif: Georgia, "Times New Roman", serif;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ground: #14171A; --surface: #1C2024; --surface-2: #22272B;
+    --ink: #ECEEF0; --ink-soft: #AEB4BB; --ink-mute: #7C838B; --line: #2C3238;
+    --accent: #83AEC7; --accent-strong: #A6C7DB; --accent-soft: #1E2E3A;
+    --ochre: #CBA05A;
+    --good-bg: #1B2E25; --good-fg: #8FC9A9; --good-line: #2C4A3B;
+    --warn-bg: #322916; --warn-fg: #D9B472; --warn-line: #4C3E20;
+    --bad-bg: #331E1E;  --bad-fg: #E0A0A0;  --bad-line: #4E2E2E;
+    --info-bg: #1E2E3A; --info-fg: #A6C7DB; --info-line: #33465A;
+  }
+}
+
+/* ---------- base ---------- */
+body {
+  background: var(--ground);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.6;
+  padding-top: 82px;
+  -webkit-font-smoothing: antialiased;
+}
+h1, h2, h3, h4, h5 {
+  font-family: var(--serif);
+  color: var(--ink);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+a { color: var(--accent); }
+a:hover, a:focus { color: var(--accent-strong); }
+hr { border-color: var(--line); }
+.container { max-width: 1040px; }
+
+/* ---------- navbar ---------- */
+.navbar-inverse {
+  background: var(--surface);
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  box-shadow: none;
+}
+.navbar { min-height: 64px; }
+.navbar-inverse .navbar-brand,
+.navbar-inverse .navbar-brand:hover {
+  color: var(--ink);
+  font-family: var(--serif);
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 34px;
+}
+.navbar-inverse .navbar-nav > li > a { color: var(--ink-soft); font-weight: 500; }
+.navbar-inverse .navbar-nav > li > a:hover,
+.navbar-inverse .navbar-nav > li > a:focus { color: var(--ink); background: transparent; }
+.navbar-inverse .navbar-toggle { border-color: var(--line); }
+.navbar-inverse .navbar-toggle:hover,
+.navbar-inverse .navbar-toggle:focus { background: var(--surface-2); }
+.navbar-inverse .navbar-toggle .icon-bar { background: var(--ink-soft); }
+.navbar-inverse .navbar-collapse { border-color: var(--line); }
+
+/* ---------- botones ---------- */
+.btn {
+  font-family: var(--sans);
+  font-weight: 600;
+  border-radius: var(--radius);
+  padding: 9px 16px;
+  border: 1px solid transparent;
+  box-shadow: none;
+  text-shadow: none;
+  transition: background .15s, border-color .15s, color .15s;
+}
+.btn-primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.btn-primary:hover, .btn-primary:focus, .btn-primary:active {
+  background: var(--accent-strong); border-color: var(--accent-strong); color: #fff;
+}
+.btn-default {
+  background: var(--surface); color: var(--ink); border-color: var(--line);
+}
+.btn-default:hover, .btn-default:focus {
+  background: var(--surface-2); color: var(--ink); border-color: var(--ink-mute);
+}
+.btn-info {
+  background: var(--accent-soft); color: var(--accent-strong); border-color: transparent;
+}
+.btn-info:hover, .btn-info:focus { background: var(--info-line); color: var(--accent-strong); }
+.btn-danger { background: var(--bad-fg); border-color: var(--bad-fg); color: #fff; }
+.btn-danger:hover, .btn-danger:focus { filter: brightness(0.92); color: #fff; }
+.btn-warning { background: var(--warn-bg); color: var(--warn-fg); border-color: var(--warn-line); }
+.btn-xs { padding: 3px 9px; }
+
+/* ---------- panels / cards ---------- */
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--card-radius);
+  box-shadow: none;
+}
+.panel-default > .panel-heading {
+  background: transparent;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink);
+  border-radius: var(--card-radius) var(--card-radius) 0 0;
+  padding: 16px 20px;
+}
+.panel-heading h4 { margin: 0; font-size: 18px; }
+.panel-body { padding: 8px 20px 16px; }
+
+/* ---------- list groups ---------- */
+.list-group { border-radius: var(--card-radius); }
+.list-group-item {
+  background: var(--surface);
+  border-color: var(--line);
+  color: var(--ink);
+  padding: 16px 20px;
+}
+.list-group-item:first-child { border-top-left-radius: var(--card-radius); border-top-right-radius: var(--card-radius); }
+.list-group-item:last-child { border-bottom-left-radius: var(--card-radius); border-bottom-right-radius: var(--card-radius); }
+.list-group-item h3 { font-size: 20px; margin-top: 4px; }
+.list-group-item h4 { font-size: 17px; }
+
+/* definition lists dentro de cards */
+.dl-horizontal dt { color: var(--ink-mute); font-weight: 600; }
+.dl-horizontal dd { color: var(--ink); margin-bottom: 6px; }
+
+/* ---------- formularios ---------- */
+.control-label, .form-group label, label { color: var(--ink-soft); font-weight: 600; }
+.form-control {
+  height: auto;
+  min-height: 42px;
+  padding: 10px 13px;
+  font-size: 15px;
+  color: var(--ink);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: none;
+}
+.form-control:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+textarea.form-control { min-height: 92px; }
+.help-block { color: var(--ink-mute); font-size: 13px; }
+.form-control::placeholder { color: var(--ink-mute); }
+
+/* ---------- tablas ---------- */
+.table { color: var(--ink); }
+.table > thead > tr > th {
+  border-bottom: 1px solid var(--line);
+  color: var(--ink-soft);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
+  padding: 12px 14px;
+}
+.table > tbody > tr > td { border-top: 1px solid var(--line); padding: 12px 14px; vertical-align: middle; }
+.table-striped > tbody > tr:nth-of-type(odd) { background: var(--surface-2); }
+.table-responsive {
+  border: 1px solid var(--line);
+  border-radius: var(--card-radius);
+  overflow: hidden;
+  background: var(--surface);
+}
+
+/* ---------- alerts ---------- */
+.alert { border-radius: var(--radius); border-width: 1px; }
+.alert-success { background: var(--good-bg); color: var(--good-fg); border-color: var(--good-line); }
+.alert-warning { background: var(--warn-bg); color: var(--warn-fg); border-color: var(--warn-line); }
+.alert-danger  { background: var(--bad-bg);  color: var(--bad-fg);  border-color: var(--bad-line); }
+.alert-info    { background: var(--info-bg); color: var(--info-fg); border-color: var(--info-line); }
+
+/* ---------- misc ---------- */
+.well {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--card-radius);
+  box-shadow: none;
+}
+.progress {
+  background: var(--surface-2);
+  border-radius: var(--radius);
+  box-shadow: none;
+  height: 8px;
+}
+.progress-bar { background: var(--accent); box-shadow: none; }
+::selection { background: var(--accent-soft); }
+
+/* Enlaces de contenido (fobi content_text): boton de pago mas visible */
+.panel-body a.btn, .list-group-item a.btn { text-decoration: none; }

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -9,6 +9,7 @@
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
     {% load static %}
+    <link rel="stylesheet" href="{% static "css/theme.css" %}">
     <link rel="stylesheet" href="{% static "css/signin.css" %}">
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,8 @@
     {% load static %}
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/styles.css' %}">
+    <link rel="stylesheet" href="{% static 'css/theme.css' %}">
+    <meta name="theme-color" content="#2C5169">
 
 
 </head>
@@ -24,18 +26,15 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <!-- <a class="navbar-brand" href="/">MP</a> -->
                 <a href="/" class="navbar-brand">
                     <img src="{% static 'img/logo-mp.png' %}"
-                         style="max-width:50px; margin-top: -7px;">
+                         style="max-width:44px; margin-top: -7px;">
                 </a>
-                <a href="#" class="navbar-brand">Inscripciones - MP</a>
+                <a href="/" class="navbar-brand">Movimiento Peregrino</a>
             </div>
             <div id="navbar" class="collapse navbar-collapse">
-                <ul class="nav navbar-nav">
-                    <li><a href="/login"></a></li>
+                <ul class="nav navbar-nav navbar-right">
                     {% block navbar %}{% endblock %}
-
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Estilo limpio/minimalista aplicado como capa CSS sobre el markup BS3 existente, sin tocar la lógica ni el render de fobi. Paleta azul peregrino con modo claro por defecto y oscuro automático (prefers-color-scheme).

- static/css/theme.css: tokens de diseño + overrides de navbar, botones, panels, list-group, formularios, tablas y alerts. Tipografía Georgia + sistema sans.
- base.html: enlaza theme.css, limpia el nav (marca ordenada, login oculto del nav público) y agrega meta theme-color.
- login.html + signin.css: card de login centrada y modernizada.